### PR TITLE
EID-69: fix legacy ELA domains mismatch with Dot Net implementation

### DIFF
--- a/src/main/java/org/opentestsystem/shared/contentspecid/ContentSpecIdConverter.java
+++ b/src/main/java/org/opentestsystem/shared/contentspecid/ContentSpecIdConverter.java
@@ -4,7 +4,6 @@ import org.opentestsystem.shared.contentspecid.enums.ContentSpecClaim;
 import org.opentestsystem.shared.contentspecid.enums.ContentSpecFormat;
 import org.opentestsystem.shared.contentspecid.enums.ContentSpecGrade;
 import org.opentestsystem.shared.contentspecid.enums.ContentSpecSubject;
-import org.opentestsystem.shared.contentspecid.enums.DomainCode;
 import org.opentestsystem.shared.contentspecid.exceptions.ErrorSeverity;
 import org.opentestsystem.shared.contentspecid.exceptions.ValidationException;
 import org.opentestsystem.shared.contentspecid.legacy.LegacyContentSpecIdConverter;
@@ -65,7 +64,6 @@ public class ContentSpecIdConverter {
      * @return ContentSpecId object equivalent of the given string
      * @throws ValidationException for invalid csid input that cannot be parsed
      */
-    @SuppressWarnings("WeakerAccess")
     public ContentSpecId parse(String csid) throws ValidationException {
         return parse(csid, ContentSpecGrade.UNSPECIFIED);
     }
@@ -168,9 +166,8 @@ public class ContentSpecIdConverter {
                 sb.append('.').append(id.getClaim().getValue()); // Includes the 'C' prefix
 
                 // Either Conceptual category (High School) or Domain (Grades 3-8)
-                DomainCode domain = DomainCode.fromString(id.getDomain());
-                if (domain != DomainCode.NA) {
-                    sb.append(domain == DomainCode.UNK ? id.getDomain() : domain.getValue());
+                if (!NOT_APPLICABLE.equals(id.getDomain())) {
+                    sb.append(id.getDomain());
                 }
 
                 if (isNotBlank(id.getTarget())) {

--- a/src/main/java/org/opentestsystem/shared/contentspecid/enums/DomainCode.java
+++ b/src/main/java/org/opentestsystem/shared/contentspecid/enums/DomainCode.java
@@ -78,15 +78,8 @@ public enum DomainCode {
         try {
             return valueOf(domainString.toUpperCase());
         } catch (IllegalArgumentException e) {
-            // Check against legacy values
-            for (DomainCode domain : values()) {
-                if (domainString.equalsIgnoreCase(domain.getLegacyValue())) {
-                    return domain;
-                }
-            }
+            return UNK;
         }
-
-        return UNK;
     }
 }
 

--- a/src/test/java/org/opentestsystem/shared/contentspecid/LegacyContentSpecIdConverterTest.java
+++ b/src/test/java/org/opentestsystem/shared/contentspecid/LegacyContentSpecIdConverterTest.java
@@ -3,9 +3,12 @@ package org.opentestsystem.shared.contentspecid;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.opentestsystem.shared.contentspecid.enums.ContentSpecGrade;
 import org.opentestsystem.shared.contentspecid.exceptions.ErrorSeverity;
 import org.opentestsystem.shared.contentspecid.exceptions.ValidationException;
 import org.opentestsystem.shared.contentspecid.legacy.LegacyContentSpecIdConverter;
+
+import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,6 +17,11 @@ import static org.opentestsystem.shared.contentspecid.enums.ContentSpecFormat.EL
 import static org.opentestsystem.shared.contentspecid.enums.ContentSpecFormat.MATH_V4;
 import static org.opentestsystem.shared.contentspecid.enums.ContentSpecFormat.MATH_V5;
 import static org.opentestsystem.shared.contentspecid.enums.ContentSpecFormat.MATH_V6;
+import static org.opentestsystem.shared.contentspecid.enums.ContentSpecGrade.G3;
+import static org.opentestsystem.shared.contentspecid.enums.ContentSpecGrade.G4;
+import static org.opentestsystem.shared.contentspecid.enums.ContentSpecGrade.G5;
+import static org.opentestsystem.shared.contentspecid.enums.ContentSpecGrade.G6;
+import static org.opentestsystem.shared.contentspecid.enums.ContentSpecGrade.GHS;
 
 /**
  * Created by Greg Charles on 11/9/18.
@@ -78,4 +86,149 @@ class LegacyContentSpecIdConverterTest {
             fail("Wrong exception type: " + t.getCause());
         }
     }
+
+
+    @Test
+    void shouldTranslateLegacyElaDomains() {
+        ContentSpecId id;
+
+        try {
+
+            for (ContentSpecGrade grade : range(G3, GHS)) {
+                for (int target = 1; target <= 7; target++) {
+                    id = parser.parse("SBAC-ELA-v1:1-LT|" + target, grade);
+                    assertThat(id.getDomain(), is("RL"));
+                }
+
+                for (int target = 8; target <= 14; target++) {
+                    id = parser.parse("SBAC-ELA-v1:1-IT|" + target, grade);
+                    assertThat(id.getDomain(), is("RI"));
+                }
+            }
+
+            for (ContentSpecGrade grade : range(G3, G5)) {
+                for (int target = 1; target <= 2; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WN"));
+                }
+                for (int target = 3; target <= 5; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WI"));
+                }
+                for (int target = 6; target <= 7; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WO"));
+                }
+                for (int target = 8; target <= 10; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WG"));
+                }
+            }
+
+            for (ContentSpecGrade grade : range(G6, GHS)) {
+                for (int target = 1; target <= 2; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WN"));
+                }
+                for (int target = 3; target <= 5; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WE"));
+                }
+                for (int target = 6; target <= 7; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WA"));
+                }
+                for (int target = 8; target <= 10; target++) {
+                    id = parser.parse("SBAC-ELA-v1:2-W|" + target, grade);
+                    assertThat(id.getDomain(), is("WG"));
+                }
+            }
+
+            for (ContentSpecGrade grade : range(G3, GHS)) {
+                for (int target = 1; target <= 10; target++) {
+                    id = parser.parse("SBAC-ELA-v1:3-L|" + target, grade);
+                    assertThat(id.getDomain(), is("SL"));
+                }
+            }
+
+            for (ContentSpecGrade grade : range(G3, GHS)) {
+                for (int target = 1; target <= 10; target++) {
+                    id = parser.parse("SBAC-ELA-v1:4-CR|" + target, grade);
+                    assertThat(id.getDomain(), is("R"));
+                }
+            }
+        } catch (ValidationException e) {
+            fail("Parse exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void shouldNotTranslateElaDomainsWhenNoTarget() {
+        try {
+            ContentSpecId id = parser.parse("SBAC-ELA-v1:1-LT", G5);
+            assertThat(id.getDomain(), is("LT"));
+        } catch (ValidationException e) {
+            fail("Parse exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void shouldHandlePartialIds() {
+        ContentSpecIdConverter formatter = new ContentSpecIdConverter();
+        ContentSpecId id;
+        try {
+            id = parser.parse("SBAC-MA-v6:1", G4);
+            assertThat(formatter.format(id), is("M.G4.C1"));
+            id = parser.parse("SBAC-MA-v6:1|P", G4);
+            assertThat(formatter.format(id), is("M.G4.C1"));
+            id = parser.parse("SBAC-MA-v6:1|P|TS01", G4);
+            assertThat(formatter.format(id), is("M.G4.C1"));
+            id = parser.parse("SBAC-MA-v6:1|P|TS01|A-4", G4);
+            assertThat(formatter.format(id), is("M.G4.C1OA.TA"));
+        } catch (ValidationException e) {
+            fail("Parse exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void shouldErrorOnInvalidContentCategory() {
+        try {
+            parser.parse("SBAC-MA-v6:1|S|TS01|A-4");
+            fail("Invalid Content Category");
+        } catch (ValidationException e) {
+            // OK
+        }
+    }
+
+    @Test
+    void shouldErrorOnInvalidEmphasis() {
+        try {
+            parser.parse("SBAC-MA-v5:1|OA|A-4|a/s|4.OA.2");
+            fail("Invalid Emphasis");
+        } catch (ValidationException e) {
+            // OK
+        }
+    }
+
+    // Returns range of grades
+    private ContentSpecGrade[] range(ContentSpecGrade start, ContentSpecGrade end) {
+        ContentSpecGrade [] all = ContentSpecGrade.values();
+        int startIndex = -1;
+        int endIndex = -1;
+        for (int i = 0; i < all.length; i++) {
+            if (all[i] == start) {
+                startIndex = i;
+            }
+            if (all[i] == end) {
+                endIndex = i;
+            }
+        }
+
+        if (startIndex < 0 || endIndex < 0 || endIndex < startIndex) {
+            throw new RuntimeException("Cannot get range for grades " + start + " and " + end);
+        }
+
+        return Arrays.copyOfRange(all, startIndex, endIndex + 1);
+    }
 }
+


### PR DESCRIPTION
Legacy domains are translated to enhanced format when grade and target are present. The library was mistakenly trying to translate domain strings even when the target value was not present.